### PR TITLE
Removed Python ':' remnants that caused the Ruby gem to fail.

### DIFF
--- a/rubygem/lib/dstk.rb
+++ b/rubygem/lib/dstk.rb
@@ -28,7 +28,7 @@ module DSTK
           
       @api_base = options[:api_base]
 
-      if options[:check_version]:
+      if options[:check_version]
         self.check_version()
       end
     end
@@ -81,7 +81,7 @@ module DSTK
       required_version = 50
       response = json_api_call('/info')
       actual_version = response['version']
-      if actual_version < required_version:
+      if actual_version < required_version
         raise "DSTK: Version #{actual_version.to_s} found but #{required_version.to_s} is required"
       end
     end


### PR DESCRIPTION
Upon requiring the Gem (`require 'dstk'`) I would get this error:

```
SyntaxError: /Users/campeterson/.rvm/gems/ruby-1.9.3-p392/gems/dstk-0.50.1/lib/dstk.rb:31: syntax error, unexpected ':', expecting keyword_then or ';' or '\n'
/Users/campeterson/.rvm/gems/ruby-1.9.3-p392/gems/dstk-0.50.1/lib/dstk.rb:84: syntax error, unexpected tLABEL
/Users/campeterson/.rvm/gems/ruby-1.9.3-p392/gems/dstk-0.50.1/lib/dstk.rb:157: syntax error, unexpected keyword_end, expecting $end
from /Users/campeterson/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:60:in `require'
```

Turned out to be a couple of `:` that may have been left over from the conversion from Python.
