### PR TITLE
Fix for #39: Set twofishes' JVM heap size to larger default

### DIFF
--- a/twofishesd.sh
+++ b/twofishesd.sh
@@ -2,4 +2,4 @@
 # The default locale for Upstart scripts is empty, which causes unicode argument
 # parsing to silently fail in the TwoFishes Java server code!
 export LANG=en_US.UTF-8
-java -jar /home/ubuntu/sources/twofishes/bin/twofishes.jar --hfile_basepath /home/ubuntu/sources/twofishes/data/latest/
+java -Xmx1500M -jar /home/ubuntu/sources/twofishes/bin/twofishes.jar --hfile_basepath /home/ubuntu/sources/twofishes/data/latest/

--- a/views/developerdocs.haml
+++ b/views/developerdocs.haml
@@ -801,7 +801,7 @@
         %td= "ami-c15dfadc"
 
     :markdown
-      Start a new instance from this image (for example with `ec2-run-instances ami-9386d1fa -t m1.large -z us-east-1d`), wait a couple of minutes for the machine to boot up, and then paste the public DNS name of the instance into your browser. You should see the normal home page of this site. You can test that it's working by pasting text into the main input. You can then just change your code base URL to that DNS name, and start using the API from your own server immediately. If you don't, check to make sure that your security group rules allow you to access port 80.
+      Start a new instance from this image (for example with `ec2-run-instances ami-9386d1fa -t m1.large -z us-east-1d`), wait a couple of minutes for the machine to boot up, and then paste the public DNS name of the instance into your browser. You should see the normal home page of this site. You can test that it's working by pasting text into the main input. You can then just change your code base URL to that DNS name, and start using the API from your own server immediately. If you don't, check to make sure that your security group rules allow you to access port 80. Note: due to the memory requirements of some DSTK components, the AMI may not function properly on instances smaller than an m1.medium.
 
     %a{:name=>"vagrant"}
     :markdown

--- a/views/developerdocs.haml
+++ b/views/developerdocs.haml
@@ -801,7 +801,7 @@
         %td= "ami-c15dfadc"
 
     :markdown
-      Start a new instance from this image (for example with `ec2-run-instances ami-9386d1fa -t m1.large -z us-east-1d`), wait a couple of minutes for the machine to boot up, and then paste the public DNS name of the instance into your browser. You should see the normal home page of this site. You can test that it's working by pasting text into the main input. You can then just change your code base URL to that DNS name, and start using the API from your own server immediately. If you don't, check to make sure that your security group rules allow you to access port 80. Note: due to the memory requirements of some DSTK components, the AMI may not function properly on instances smaller than an m1.medium.
+      Start a new instance from this image (for example with `ec2-run-instances ami-9386d1fa -t m1.large -z us-east-1d`), wait a couple of minutes for the machine to boot up, and then paste the public DNS name of the instance into your browser. You should see the normal home page of this site. You can test that it's working by pasting text into the main input. You can then just change your code base URL to that DNS name, and start using the API from your own server immediately. If you don't, check to make sure that your security group rules allow you to access port 80. Note: due to the memory requirements of some DSTK components, the AMI may not function properly on instances smaller than an m1.large.
 
     %a{:name=>"vagrant"}
     :markdown


### PR DESCRIPTION
Addresses issue #39 

I tried a few times to use a lower default than 1500MB on an m1.medium, but didn't have any luck. Even 900MB was too little for twofishes to start up without an OOM. I added a note recommending at least an m1.large in the developerdocs. It's possible that someone with more JVM-fu than me might be able to revise it.
